### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Simple sheet of fabric simulated using mass spring system
 
-thead are used to spread the computation over all accessible nodes.
+threads are used to spread the computation over all accessible nodes.
 
 Use glut in an simple and very old manner
 


### PR DESCRIPTION
## Summary
- correct README typos

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842341981dc8324abecd6368ef9ca35