### PR TITLE
fix: store normalized normals

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -163,6 +163,7 @@ void build_norm() {
     for (auto j : range(sz)) {
       auto n = napkin[i][j].normal;
       n *= -1.0f / n.len();
+      napkin[i][j].normal = n;
     }
 }
 


### PR DESCRIPTION
## Summary
- normalize and store normals in `build_norm`

## Testing
- `g++ -march=native -O3 main.cpp -lglut -lGL -pthread -o napkin` *(fails: `GL/glut.h` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684233fe053483248b48fbfc6e607ecf