### PR TITLE
Fix lighting array scope

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -118,6 +118,16 @@ static int w = 400, h = 400;
 
 static V3f camera(-3.0f, -3.0f, 3.0f);
 
+const GLfloat light_ambient[] = {0.0f, 0.0f, 0.0f, 1.0f};
+const GLfloat light_diffuse[] = {1.0f, 1.0f, 1.0f, 1.0f};
+const GLfloat light_specular[] = {1.0f, 1.0f, 1.0f, 1.0f};
+const GLfloat light_position[] = {2.0f, 5.0f, 5.0f, 0.0f};
+
+const GLfloat mat_ambient[] = {0.7f, 0.7f, 0.7f, 1.0f};
+const GLfloat mat_diffuse[] = {0.8f, 0.8f, 0.8f, 1.0f};
+const GLfloat mat_specular[] = {1.0f, 1.0f, 1.0f, 1.0f};
+const GLfloat high_shininess[] = {100.0f};
+
 static void do_resize() {
   const float ar = (float)w / (float)h;
 
@@ -402,15 +412,6 @@ static void idle(void)
     glutPostRedisplay();
 }
 
-const GLfloat light_ambient[] = {0.0f, 0.0f, 0.0f, 1.0f};
-const GLfloat light_diffuse[] = {1.0f, 1.0f, 1.0f, 1.0f};
-const GLfloat light_specular[] = {1.0f, 1.0f, 1.0f, 1.0f};
-const GLfloat light_position[] = {2.0f, 5.0f, 5.0f, 0.0f};
-
-const GLfloat mat_ambient[] = {0.7f, 0.7f, 0.7f, 1.0f};
-const GLfloat mat_diffuse[] = {0.8f, 0.8f, 0.8f, 1.0f};
-const GLfloat mat_specular[] = {1.0f, 1.0f, 1.0f, 1.0f};
-const GLfloat high_shininess[] = {100.0f};
 
 /* Program entry point */
 


### PR DESCRIPTION
## Summary
- move lighting and material array definitions above `display`

## Testing
- `g++ -std=c++17 -march=native -O3 main.cpp -lglut -lGL -pthread -o napkin.out` *(fails: `GL/glut.h` missing)*

------
https://chatgpt.com/codex/tasks/task_e_6842391334608324b322cfed974d5570